### PR TITLE
Fix package name validation

### DIFF
--- a/internal/config/package.go
+++ b/internal/config/package.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	validPackageNameRegex    = `^[a-zA-Z0-9][a-zA-Z0-9-_/.]*[a-zA-Z0-9]$`
+	validPackageNameRegex    = `^[\pL0-9_.-]+$`
 	validPackageVersionRegex = `^\d+\.\d+\.\d+$`
 )
 

--- a/internal/config/package.go
+++ b/internal/config/package.go
@@ -5,6 +5,7 @@
 package config
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 
@@ -88,7 +89,7 @@ func (p *Package) validate() error {
 	nameRegex := regexp.MustCompile(validPackageNameRegex)
 
 	if !nameRegex.MatchString(p.Name) {
-		return ErrPackageInvalidName
+		return fmt.Errorf("%w: %s", ErrPackageInvalidName, p.Name)
 	}
 
 	if p.Description == "" {


### PR DESCRIPTION
### What does this PR do?

Simplify the package name validation regex to match what Go expects better and allow for names like `x`, which wasn't allowed before, but is allowed by Go.

### Review checklist

Before submitting your PR, please review the following:

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) file.
- [x] My changes are focused and address a single concern.
- [ ] I have added/updated tests that prove my fix is effective or that
  my feature works.
- [x] New and existing tests pass locally with my changes.
- [ ] I have added necessary documentation or made changes to
  documentation (if appropriate).
- [x] My changes generate no new warnings or errors.
- [x] My code follows the code style of this project.

## Developer's certificate of origin
By submitting this pull request, I certify that:

- [x] The contribution is my own original work.
- [x] I have the right to submit it under the project's license.
- [x] I understand and agree to the project's contributing guidelines.
